### PR TITLE
Remove grep color option dependence on dircolors

### DIFF
--- a/assets/bash/rc.d/55-coreutils-aliases.sh
+++ b/assets/bash/rc.d/55-coreutils-aliases.sh
@@ -4,11 +4,11 @@ if __nidus_has dircolors; then
     alias ls='ls --color=auto'
     alias dir='dir --color=auto'
     alias vdir='vdir --color=auto'
-
-    alias grep='grep --color=auto'
-    alias fgrep='fgrep --color=auto'
-    alias egrep='egrep --color=auto'
 fi
+
+alias grep='grep --color=auto'
+alias fgrep='fgrep --color=auto'
+alias egrep='egrep --color=auto'
 
 # one-letter shortcuts
 alias -- -='cd ..'


### PR DESCRIPTION
Both the BSD version shipped with MacOS and the GNU version have --color=auto option.