### PR TITLE
Prioritize /etc/bashrc

### DIFF
--- a/assets/bash/rc
+++ b/assets/bash/rc
@@ -1,7 +1,3 @@
-if [ -f /etc/bashrc ]; then
-    source /etc/bashrc
-fi
-
 if [ "${BASH_VERSINFO[0]}" -lt "$(<$HOME/.nidus_site_config/nidus/install.d/minimum_bash_version/major)" ]; then
     cat $HOME/.nidus_site_config/nidus/assets/bash/banners/bash_not_supported.txt
     return 1

--- a/configs/100-bashhomerc/bashrc
+++ b/configs/100-bashhomerc/bashrc
@@ -4,6 +4,10 @@
 # THIS FILE IS NOT UNDER NIDUS VERSION CONTROL.
 # THIS FILE WILL BE BACKED UP AND RESET ON NIDUS REINSTALLATION.
 
+if [ -f /etc/bashrc ]; then
+    source /etc/bashrc
+fi
+
 [ -z "$PS1" ] && return
 
 __nidus_bashrc="$HOME/.nidus_site_config/nidus/assets/bash/rc"


### PR DESCRIPTION
In some cases, remote connections depend on local `bashrc` to source the remote `/etc/bashrc`. In non-interactive remote connections, `/etc/bashrc` should still be sourced.
As a result, sourcing `/etc/bashrc` should be moved ahead of the early exit by `[ -z "$PS1" ] && return`